### PR TITLE
chore: DEVPLAT-7373 fix Node.js 20 deprecated GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,9 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
-      - uses: hashicorp/setup-terraform@v1
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: 0.12.25
       - run: terraform fmt
@@ -28,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Checkout'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
       - name: Set up Python environment
         uses: actions/setup-python@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
       - name: 'Checkout'
         uses: actions/checkout@v6
       - name: Set up Python environment
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v6
         with:
           python-version: "3.8"
       - run: pip install flake8 mypy black


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions that use the deprecated Node.js 20 runtime to Node.js 24 compatible versions.

Node.js 20 actions will be forced to run on Node.js 24 by default starting **June 2nd, 2026**. See the [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

**Changes made:**
- `actions/checkout@v2` → `actions/checkout@v6`
- `hashicorp/setup-terraform@v1` → `hashicorp/setup-terraform@v4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVPLAT-7373](https://scribd.atlassian.net/browse/DEVPLAT-7373)


[DEVPLAT-7373]: https://scribdjira.atlassian.net/browse/DEVPLAT-7373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version bumps to workflow actions only; behavior changes are limited to upstream action updates and should not affect application code.
> 
> **Overview**
> Updates `.github/workflows/build.yml` to use newer, Node.js-24-compatible GitHub Actions: `actions/checkout@v2`  `@v6`, `hashicorp/setup-terraform@v1`  `@v4`, and `actions/setup-python@v1`  `@v6`.
> 
> No CI steps or tool versions change beyond the action runner implementations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd8640687ed7a3a5adf3b2d5be908b4abf395ec7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->